### PR TITLE
add x86_64 inline asm to direct_threading and optimized_direct_threading

### DIFF
--- a/Rust/direct-threading/src/bytecode.rs
+++ b/Rust/direct-threading/src/bytecode.rs
@@ -37,6 +37,33 @@ macro_rules! dispatch {
     }
 }
 
+/// Macro to get the label address. x86_64 Only.
+#[cfg(target_arch = "x86_64")]
+macro_rules! label_addr {
+    ($name:literal) => (
+        {
+            let addr: usize;
+            asm!(
+                concat!("lea    {},", $name, "[rip]"),
+                out(reg) addr,
+            );
+            addr
+        }
+    )
+}
+
+/// Macro to dispatch based on jump table and opcode. x86_64 Only.
+#[cfg(target_arch = "x86_64")]
+macro_rules! dispatch {
+    ($pc:expr, $dispatch_sequence:expr) => {
+        let addr = $dispatch_sequence[$pc as usize];
+        asm!(
+            "jmp {}",
+            in(reg) addr,
+        );
+    }
+}
+
 /// Type for Bytecode
 pub type Bytecode = u32;
 

--- a/Rust/optimized_direct_threading/src/bytecode.rs
+++ b/Rust/optimized_direct_threading/src/bytecode.rs
@@ -38,6 +38,33 @@ macro_rules! dispatch {
     }
 }
 
+/// Macro to get the label address. x86_64 Only.
+#[cfg(target_arch = "x86_64")]
+macro_rules! label_addr {
+    ($name:literal) => (
+        {
+            let addr: usize;
+            asm!(
+                concat!("lea    {},", $name, "[rip]"),
+                out(reg) addr,
+            );
+            addr
+        }
+    )
+}
+
+/// Macro to dispatch based on jump table and opcode. x86_64 Only.
+#[cfg(target_arch = "x86_64")]
+macro_rules! dispatch {
+    ($pc:expr, $dispatch_sequence:expr) => {
+        let addr = $dispatch_sequence[$pc as usize];
+        asm!(
+            "jmp {}",
+            in(reg) addr,
+        );
+    }
+}
+
 /// Type for Bytecode
 pub type Bytecode = u32;
 


### PR DESCRIPTION
cargo criterion results on Intel 7600k @ 4.8Ghz:

direct threading time: [14.375 ms 14.376 ms 14.378 ms]

optimized direct threading time: [10.148 ms 10.155 ms 10.163 ms]

resubmitted with signed commit
