### PR TITLE
Fix off-by-one bug in direct-threading

### DIFF
--- a/C/direct-threading/direct_threading.c
+++ b/C/direct-threading/direct_threading.c
@@ -4,7 +4,7 @@
 #define WARMING_UP_ITERATIONS 10
 #define NUM_OF_ITERATIONS 100
 
-#define DISPATCH() goto *dispatch_table[GET_OPCODE(program[pc++])]
+#define DISPATCH() goto *dispatch_table[GET_OPCODE(program[++pc])]
 
 typedef enum
 {
@@ -72,7 +72,7 @@ int main()
         }
         clock_gettime(CLOCK_MONOTONIC_RAW, &ts_start);
         pc = 0;
-        DISPATCH();
+	goto *dispatch_table[GET_OPCODE(program[pc])];
     do_load:
         memory[GET_OPERAND_A(program[pc])] = GET_OPERAND_IMM(program[pc]);
         DISPATCH();


### PR DESCRIPTION
Direct threading in C has a bug: the pc counter points one past where we're actually using it, and hence the loop only runs once, due to the jmpne comparsion comparing 'print 0 0' instead.